### PR TITLE
Add Earlier and Overdue sections to Today/Upcoming views

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -310,6 +310,7 @@ export interface UpcomingViewDate {
 }
 
 export interface UpcomingView {
+  overdue: Task[]
   dates: UpcomingViewDate[]
   earlier: Task[]
 }

--- a/frontend/src/pages/TodayView.tsx
+++ b/frontend/src/pages/TodayView.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { format } from 'date-fns'
 import { useToday } from '../hooks/queries'
 import { SortableTaskList } from '../components/SortableTaskList'
 import { TaskItem } from '../components/TaskItem'
@@ -26,10 +27,12 @@ export function TodayView() {
 
   return (
     <div className="mx-auto max-w-2xl p-6">
+      <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Today</h2>
+
       {/* Overdue tasks */}
       {data?.overdue && data.overdue.length > 0 && (
-        <div className="mb-8">
-          <h1 className="mb-3 text-2xl font-bold text-red-600 dark:text-red-400">Overdue</h1>
+        <div className="mb-6">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Overdue</h3>
           <div className="space-y-0.5">
             {data.overdue.map((task) => (
               <TaskItem key={task.id} task={task} />
@@ -40,8 +43,8 @@ export function TodayView() {
 
       {/* Earlier: past-dated tasks without overdue deadline */}
       {data?.earlier && data.earlier.length > 0 && (
-        <div className="mb-8">
-          <h2 className="mb-3 text-lg font-semibold text-neutral-800 dark:text-neutral-200">Earlier</h2>
+        <div className="mb-6">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Earlier</h3>
           <div className="space-y-0.5">
             {data.earlier.map((task) => (
               <TaskItem key={task.id} task={task} />
@@ -54,13 +57,12 @@ export function TodayView() {
       {sections.map((section) => {
         const hasTasks = section.tasks.length > 0
         if (!hasTasks && section.title !== 'Today') return null
+        const sectionTitle = section.title === 'Today'
+          ? `Today - ${format(new Date(), 'EEE, MMM d')}`
+          : section.title
         return (
-          <div key={section.title} className="mb-8">
-            {section.title === 'Today' ? (
-              <h1 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{section.title}</h1>
-            ) : (
-              <h2 className="mb-3 text-lg font-semibold text-neutral-800 dark:text-neutral-200">{section.title}</h2>
-            )}
+          <div key={section.title} className="mb-6">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{sectionTitle}</h3>
             {!hasTasks ? (
               <p className="py-4 text-sm text-neutral-400">No tasks</p>
             ) : (

--- a/frontend/src/pages/UpcomingView.tsx
+++ b/frontend/src/pages/UpcomingView.tsx
@@ -1,5 +1,6 @@
 import { useUpcoming } from '../hooks/queries'
 import { TaskGroup } from '../components/TaskGroup'
+import { TaskItem } from '../components/TaskItem'
 import { formatRelativeDate } from '../lib/format-date'
 
 export function UpcomingView() {
@@ -16,11 +17,21 @@ export function UpcomingView() {
   return (
     <div className="mx-auto max-w-2xl p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Upcoming</h2>
+      {data?.overdue && data.overdue.length > 0 && (
+        <div className="mb-6">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Overdue</h3>
+          <div className="space-y-0.5">
+            {data.overdue.map((task) => (
+              <TaskItem key={task.id} task={task} />
+            ))}
+          </div>
+        </div>
+      )}
       {data?.earlier && data.earlier.length > 0 && (
         <TaskGroup title="Earlier" tasks={data.earlier} />
       )}
       {!data?.dates || data.dates.length === 0 ? (
-        !data?.earlier?.length && (
+        !data?.earlier?.length && !data?.overdue?.length && (
           <p className="py-12 text-center text-sm text-neutral-400">
             Nothing scheduled yet.
           </p>

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -353,6 +353,7 @@ type TaskGroup struct {
 }
 
 type UpcomingView struct {
+	Overdue []TaskListItem `json:"overdue"`
 	Dates   []DateGroup    `json:"dates"`
 	Earlier []TaskListItem `json:"earlier"`
 }

--- a/internal/repository/views.go
+++ b/internal/repository/views.go
@@ -195,6 +195,27 @@ func (r *ViewRepository) Upcoming(from string, days int) (*model.UpcomingView, e
 		dates = []model.DateGroup{}
 	}
 
+	// Overdue: tasks with deadline before today
+	overdueRows, err := r.db.Query(`
+		SELECT t.id, t.title, t.notes, t.status, t.when_date, t.when_evening, t.high_priority,
+			t.deadline, t.project_id, t.area_id, t.heading_id,
+			t.sort_order_today, t.sort_order_project, t.sort_order_heading,
+			t.completed_at, t.canceled_at, t.deleted_at, t.created_at, t.updated_at,
+			COALESCE((SELECT COUNT(*) FROM checklist_items WHERE task_id = t.id), 0),
+			COALESCE((SELECT COUNT(*) FROM checklist_items WHERE task_id = t.id AND completed = 1), 0),
+			CASE WHEN t.notes != '' THEN 1 ELSE 0 END,
+			CASE WHEN EXISTS(SELECT 1 FROM attachments WHERE task_id = t.id AND type = 'link') THEN 1 ELSE 0 END,
+			CASE WHEN EXISTS(SELECT 1 FROM attachments WHERE task_id = t.id AND type = 'file') THEN 1 ELSE 0 END,
+			CASE WHEN EXISTS(SELECT 1 FROM repeat_rules WHERE task_id = t.id) THEN 1 ELSE 0 END
+		FROM tasks t
+		WHERE t.status = 'open' AND t.deadline < ? AND t.deleted_at IS NULL
+		ORDER BY t.deadline ASC`, from)
+	if err != nil {
+		return nil, err
+	}
+	defer overdueRows.Close()
+	overdueTasks := scanTaskListItems(r.db, overdueRows)
+
 	// Earlier: tasks with when_date before the from date, not someday, not overdue
 	earlierRows, err := r.db.Query(`
 		SELECT t.id, t.title, t.notes, t.status, t.when_date, t.when_evening, t.high_priority,
@@ -219,7 +240,7 @@ func (r *ViewRepository) Upcoming(from string, days int) (*model.UpcomingView, e
 	defer earlierRows.Close()
 	earlierTasks := scanTaskListItems(r.db, earlierRows)
 
-	return &model.UpcomingView{Dates: dates, Earlier: earlierTasks}, nil
+	return &model.UpcomingView{Overdue: overdueTasks, Dates: dates, Earlier: earlierTasks}, nil
 }
 
 func (r *ViewRepository) Anytime() (*model.AnytimeView, error) {


### PR DESCRIPTION
## Summary
- Add "Earlier" section to Today and Upcoming views for past-dated tasks without overdue deadlines
- Add "Overdue" section to Upcoming view with backend query support
- Restyle all section headers (Overdue, Earlier, Today, This Evening) to unified small uppercase style matching TaskGroup
- Add page title to TodayView; Today section header now shows formatted date (e.g. "TODAY - THU, FEB 19")
- Disable drag-and-drop sorting in Overdue and Earlier sections

## Test plan
- [ ] Verify Overdue/Earlier sections appear in Today view when applicable tasks exist
- [ ] Verify Overdue/Earlier sections appear in Upcoming view when applicable tasks exist
- [ ] Confirm all section headers use consistent small uppercase styling
- [ ] Confirm Today section header shows current date
- [ ] Confirm drag-and-drop is disabled in Overdue and Earlier sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)