### PR TITLE
Show completed tasks in Today, Area, and Project views

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -184,6 +184,7 @@ export interface HeadingWithTasks extends Heading {
 export interface ProjectDetail extends Project {
   headings: HeadingWithTasks[]
   tasks_without_heading: Task[]
+  completed_tasks: Task[]
 }
 
 export interface CreateProjectRequest {
@@ -219,6 +220,7 @@ export interface Area {
 export interface AreaDetail extends Area {
   projects: Project[]
   tasks: Task[]
+  completed_tasks: Task[]
 }
 
 export interface CreateAreaRequest {
@@ -302,6 +304,7 @@ export interface TodayView {
   sections: TodayViewSection[]
   overdue: Task[]
   earlier: Task[]
+  completed: Task[]
 }
 
 export interface UpcomingViewDate {

--- a/frontend/src/components/CompletedTasksSection.tsx
+++ b/frontend/src/components/CompletedTasksSection.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import type { Task } from '../api/types'
+import { TaskItem } from './TaskItem'
+
+interface CompletedTasksSectionProps {
+  tasks: Task[]
+  showProject?: boolean
+}
+
+export function CompletedTasksSection({ tasks, showProject }: CompletedTasksSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (tasks.length === 0) return null
+
+  return (
+    <div className="mt-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="text-xs text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
+      >
+        {expanded ? 'Hide completed tasks' : `Show ${tasks.length} completed task${tasks.length === 1 ? '' : 's'}`}
+      </button>
+      {expanded && (
+        <div className="mt-2 space-y-0.5">
+          {tasks.map((task) => (
+            <TaskItem key={task.id} task={task} showProject={showProject} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AreaView.tsx
+++ b/frontend/src/pages/AreaView.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router'
 import { Trash2 } from 'lucide-react'
 import { useArea, useDeleteArea } from '../hooks/queries'
 import { TaskItem } from '../components/TaskItem'
+import { CompletedTasksSection } from '../components/CompletedTasksSection'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 
 export function AreaView() {
@@ -84,6 +85,8 @@ export function AreaView() {
           </div>
         </div>
       )}
+
+      <CompletedTasksSection tasks={area.completed_tasks} showProject={false} />
 
       <ConfirmDialog
         open={showDelete}

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -4,6 +4,7 @@ import { Trash2 } from 'lucide-react'
 import { useProject, useDeleteProject } from '../hooks/queries'
 import { TaskGroup } from '../components/TaskGroup'
 import { SortableTaskList } from '../components/SortableTaskList'
+import { CompletedTasksSection } from '../components/CompletedTasksSection'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 
 export function ProjectView() {
@@ -74,6 +75,8 @@ export function ProjectView() {
           sortField="sort_order_heading"
         />
       ))}
+
+      <CompletedTasksSection tasks={project.completed_tasks} showProject={false} />
 
       <ConfirmDialog
         open={showDelete}

--- a/frontend/src/pages/TodayView.tsx
+++ b/frontend/src/pages/TodayView.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { useToday } from '../hooks/queries'
 import { SortableTaskList } from '../components/SortableTaskList'
 import { TaskItem } from '../components/TaskItem'
+import { CompletedTasksSection } from '../components/CompletedTasksSection'
 
 export function TodayView() {
   const { data, isLoading } = useToday()
@@ -75,6 +76,8 @@ export function TodayView() {
           </div>
         )
       })}
+
+      {data?.completed && <CompletedTasksSection tasks={data.completed} />}
     </div>
   )
 }

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -33,8 +33,9 @@ type Area struct {
 
 type AreaDetail struct {
 	Area
-	Projects []ProjectListItem `json:"projects"`
-	Tasks    []TaskListItem    `json:"tasks"`
+	Projects       []ProjectListItem `json:"projects"`
+	Tasks          []TaskListItem    `json:"tasks"`
+	CompletedTasks []TaskListItem    `json:"completed_tasks"`
 }
 
 type Project struct {
@@ -62,6 +63,7 @@ type ProjectDetail struct {
 	ProjectListItem
 	Headings             []HeadingWithTasks `json:"headings"`
 	TasksWithoutHeading  []TaskListItem     `json:"tasks_without_heading"`
+	CompletedTasks       []TaskListItem     `json:"completed_tasks"`
 }
 
 type Heading struct {
@@ -337,9 +339,10 @@ type TaskFilters struct {
 // --- View response types ---
 
 type TodayView struct {
-	Sections []TodaySection `json:"sections"`
-	Overdue  []TaskListItem `json:"overdue"`
-	Earlier  []TaskListItem `json:"earlier"`
+	Sections  []TodaySection `json:"sections"`
+	Overdue   []TaskListItem `json:"overdue"`
+	Earlier   []TaskListItem `json:"earlier"`
+	Completed []TaskListItem `json:"completed"`
 }
 
 type TodaySection struct {


### PR DESCRIPTION
## Summary
- Extends backend API responses for Today, Area, and Project views to include completed tasks (completed, canceled, wont_do statuses)
- Today view: shows tasks completed today
- Area view: shows standalone tasks (no project) completed today
- Project view: shows all-time completed tasks
- Adds reusable `CompletedTasksSection` frontend component — collapsed by default, toggles with "Show N completed tasks" link

## Test plan
- [ ] Complete a task on Today view, verify "Show 1 completed task" link appears at bottom
- [ ] Click the link to expand, verify completed task is shown with strikethrough styling
- [ ] Navigate to a project, complete a task, verify completed section appears
- [ ] Navigate to an area page, complete a standalone task, verify completed section appears
- [ ] Verify canceled/wont_do tasks also appear in completed sections
- [ ] Verify `go test ./...` passes
- [ ] Verify `npx tsc -b --noEmit` compiles without errors

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)