### PR TITLE
Add tag color support

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -29,12 +29,14 @@ export interface LoginRequest {
 export interface TagRef {
   id: string
   title: string
+  color: string | null
 }
 
 // Tags (full)
 export interface Tag {
   id: string
   title: string
+  color: string | null
   parent_tag_id: string | null
   sort_order: number
   task_count: number
@@ -273,6 +275,7 @@ export interface CreateTagRequest {
 
 export interface UpdateTagRequest {
   title?: string
+  color?: string | null
   parent_tag_id?: string | null
   sort_order?: number
 }

--- a/frontend/src/components/SortableTaskItem.tsx
+++ b/frontend/src/components/SortableTaskItem.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from '../stores/app'
 import { TaskDetail } from './TaskDetail'
 import { useResolveTags } from '../hooks/useResolveTags'
 import { formatRelativeDate } from '../lib/format-date'
+import { getTagPillClasses } from '../lib/tag-colors'
 import { TagAutocomplete } from './TagAutocomplete'
 import { ProjectAutocomplete } from './ProjectAutocomplete'
 import { PriorityAutocomplete } from './PriorityAutocomplete'
@@ -328,7 +329,7 @@ export function SortableTaskItem({
             {!editing && task.tags.map((tag) => (
               <span
                 key={tag.id}
-                className="group/tag inline-flex items-center gap-0.5 rounded-full bg-neutral-100 py-0.5 pl-2 pr-1.5 text-xs text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300"
+                className={`group/tag inline-flex items-center gap-0.5 rounded-full py-0.5 pl-2 pr-1.5 text-xs ${getTagPillClasses(tag.color)}`}
               >
                 {tag.title}
                 <button

--- a/frontend/src/components/TaskItem.tsx
+++ b/frontend/src/components/TaskItem.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from '../stores/app'
 import { TaskDetail } from './TaskDetail'
 import { useResolveTags } from '../hooks/useResolveTags'
 import { formatRelativeDate } from '../lib/format-date'
+import { getTagPillClasses } from '../lib/tag-colors'
 import { TaskStatusIcon } from './TaskStatusIcon'
 import { TagAutocomplete } from './TagAutocomplete'
 import { ProjectAutocomplete } from './ProjectAutocomplete'
@@ -290,7 +291,7 @@ export function TaskItem({ task, showProject = true }: TaskItemProps) {
             {!editing && task.tags.map((tag) => (
               <span
                 key={tag.id}
-                className="group/tag inline-flex items-center gap-0.5 rounded-full bg-neutral-100 py-0.5 pl-2 pr-1.5 text-xs text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300"
+                className={`group/tag inline-flex items-center gap-0.5 rounded-full py-0.5 pl-2 pr-1.5 text-xs ${getTagPillClasses(tag.color)}`}
               >
                 {tag.title}
                 <button

--- a/frontend/src/components/TaskItemDragOverlay.tsx
+++ b/frontend/src/components/TaskItemDragOverlay.tsx
@@ -1,5 +1,6 @@
 import { Check, Calendar, Flag, StickyNote, Link, Paperclip, RefreshCw } from 'lucide-react'
 import type { Task } from '../api/types'
+import { getTagPillClasses } from '../lib/tag-colors'
 import { TaskStatusIcon } from './TaskStatusIcon'
 
 interface TaskItemDragOverlayProps {
@@ -42,7 +43,7 @@ export function TaskItemDragOverlay({ task }: TaskItemDragOverlayProps) {
             {task.tags.map((tag) => (
               <span
                 key={tag.id}
-                className="inline-flex items-center rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300"
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${getTagPillClasses(tag.color)}`}
               >
                 {tag.title}
               </span>

--- a/frontend/src/lib/tag-colors.ts
+++ b/frontend/src/lib/tag-colors.ts
@@ -1,0 +1,29 @@
+export const TAG_COLORS = [
+  { name: 'red', value: 'red', bg: 'bg-red-100 dark:bg-red-900/40', text: 'text-red-700 dark:text-red-300', icon: 'text-red-500', dot: 'bg-red-500' },
+  { name: 'orange', value: 'orange', bg: 'bg-orange-100 dark:bg-orange-900/40', text: 'text-orange-700 dark:text-orange-300', icon: 'text-orange-500', dot: 'bg-orange-500' },
+  { name: 'yellow', value: 'yellow', bg: 'bg-yellow-100 dark:bg-yellow-900/40', text: 'text-yellow-700 dark:text-yellow-300', icon: 'text-yellow-500', dot: 'bg-yellow-500' },
+  { name: 'green', value: 'green', bg: 'bg-green-100 dark:bg-green-900/40', text: 'text-green-700 dark:text-green-300', icon: 'text-green-500', dot: 'bg-green-500' },
+  { name: 'teal', value: 'teal', bg: 'bg-teal-100 dark:bg-teal-900/40', text: 'text-teal-700 dark:text-teal-300', icon: 'text-teal-500', dot: 'bg-teal-500' },
+  { name: 'blue', value: 'blue', bg: 'bg-blue-100 dark:bg-blue-900/40', text: 'text-blue-700 dark:text-blue-300', icon: 'text-blue-500', dot: 'bg-blue-500' },
+  { name: 'purple', value: 'purple', bg: 'bg-purple-100 dark:bg-purple-900/40', text: 'text-purple-700 dark:text-purple-300', icon: 'text-purple-500', dot: 'bg-purple-500' },
+  { name: 'pink', value: 'pink', bg: 'bg-pink-100 dark:bg-pink-900/40', text: 'text-pink-700 dark:text-pink-300', icon: 'text-pink-500', dot: 'bg-pink-500' },
+] as const
+
+const colorMap = new Map<string, typeof TAG_COLORS[number]>(TAG_COLORS.map((c) => [c.value, c]))
+
+export function getTagColor(color: string | null | undefined) {
+  if (!color) return null
+  return colorMap.get(color) ?? null
+}
+
+export function getTagPillClasses(color: string | null | undefined) {
+  const c = getTagColor(color)
+  if (!c) return 'bg-neutral-100 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'
+  return `${c.bg} ${c.text}`
+}
+
+export function getTagIconClass(color: string | null | undefined) {
+  const c = getTagColor(color)
+  if (!c) return ''
+  return c.icon
+}

--- a/internal/database/migrations/010_tag_colors.sql
+++ b/internal/database/migrations/010_tag_colors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tags ADD COLUMN color TEXT;

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -147,14 +147,16 @@ type Attachment struct {
 type Tag struct {
 	ID          string  `json:"id"`
 	Title       string  `json:"title"`
+	Color       *string `json:"color"`
 	ParentTagID *string `json:"parent_tag_id"`
 	SortOrder   float64 `json:"sort_order"`
 	TaskCount   int     `json:"task_count,omitempty"`
 }
 
 type TagRef struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
+	ID    string  `json:"id"`
+	Title string  `json:"title"`
+	Color *string `json:"color"`
 }
 
 type Ref struct {
@@ -278,6 +280,7 @@ type CreateTagInput struct {
 
 type UpdateTagInput struct {
 	Title       *string  `json:"title"`
+	Color       *string  `json:"color"`
 	ParentTagID *string  `json:"parent_tag_id"`
 	SortOrder   *float64 `json:"sort_order"`
 	Raw         map[string]json.RawMessage `json:"-"`

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -272,7 +272,7 @@ func getRef(db *sql.DB, table, id string) *model.Ref {
 
 func getProjectTags(db *sql.DB, projectID string) []model.TagRef {
 	rows, err := db.Query(
-		"SELECT t.id, t.title FROM tags t JOIN project_tags pt ON t.id = pt.tag_id WHERE pt.project_id = ? ORDER BY t.sort_order", projectID)
+		"SELECT t.id, t.title, t.color FROM tags t JOIN project_tags pt ON t.id = pt.tag_id WHERE pt.project_id = ? ORDER BY t.sort_order", projectID)
 	if err != nil {
 		return []model.TagRef{}
 	}
@@ -280,7 +280,7 @@ func getProjectTags(db *sql.DB, projectID string) []model.TagRef {
 	var tags []model.TagRef
 	for rows.Next() {
 		var t model.TagRef
-		_ = rows.Scan(&t.ID, &t.Title)
+		_ = rows.Scan(&t.ID, &t.Title, &t.Color)
 		tags = append(tags, t)
 	}
 	if tags == nil {
@@ -359,12 +359,12 @@ func scanTaskListItems(db *sql.DB, rows *sql.Rows) []model.TaskListItem {
 		t.HasRepeatRule = hasRepeat == 1
 		// Get tags
 		tagRows, _ := db.Query(
-			"SELECT t.id, t.title FROM tags t JOIN task_tags tt ON t.id = tt.tag_id WHERE tt.task_id = ?", t.ID)
+			"SELECT t.id, t.title, t.color FROM tags t JOIN task_tags tt ON t.id = tt.tag_id WHERE tt.task_id = ?", t.ID)
 		if tagRows != nil {
 			var tags []model.TagRef
 			for tagRows.Next() {
 				var tag model.TagRef
-				_ = tagRows.Scan(&tag.ID, &tag.Title)
+				_ = tagRows.Scan(&tag.ID, &tag.Title, &tag.Color)
 				tags = append(tags, tag)
 			}
 			tagRows.Close()

--- a/internal/repository/tasks.go
+++ b/internal/repository/tasks.go
@@ -366,7 +366,7 @@ func (r *TaskRepository) Reorder(items []model.ReorderItem) error {
 
 func (r *TaskRepository) getTaskTags(taskID string) ([]model.TagRef, error) {
 	rows, err := r.db.Query(
-		"SELECT t.id, t.title FROM tags t JOIN task_tags tt ON t.id = tt.tag_id WHERE tt.task_id = ? ORDER BY t.sort_order", taskID)
+		"SELECT t.id, t.title, t.color FROM tags t JOIN task_tags tt ON t.id = tt.tag_id WHERE tt.task_id = ? ORDER BY t.sort_order", taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (r *TaskRepository) getTaskTags(taskID string) ([]model.TagRef, error) {
 	var tags []model.TagRef
 	for rows.Next() {
 		var t model.TagRef
-		_ = rows.Scan(&t.ID, &t.Title)
+		_ = rows.Scan(&t.ID, &t.Title, &t.Color)
 		tags = append(tags, t)
 	}
 	if tags == nil {


### PR DESCRIPTION
## Summary
- Tags can now have one of 8 colors (red, orange, yellow, green, teal, blue, purple, pink)
- Double-click a tag icon in the sidebar to open a color picker popover with 8 color dots + reset button
- Tag colors are reflected on sidebar tag icons and task row tag pills across all views
- SQLite migration adds `color TEXT` column to tags table
- Single-click on tag icon or title still navigates; double-click on title still renames

## Changes
- **Backend**: Migration `010_tag_colors.sql`, updated `Tag`/`TagRef`/`UpdateTagInput` models, updated all TagRef queries/scans in `tags.go`, `projects.go`, `tasks.go`
- **Frontend**: New `tag-colors.ts` utility with color mapping, new `TagSidebarItem` + inline `Popover` color picker in Sidebar, dynamic tag pill colors in `TaskItem`, `SortableTaskItem`, `TaskItemDragOverlay`

Closes #2

## Test plan
- [ ] Create a tag, verify default (no color) rendering
- [ ] Double-click tag icon in sidebar → color picker appears anchored to icon
- [ ] Select a color → icon changes color, picker closes
- [ ] Add colored tag to a task → pill shows colored background in task lists
- [ ] Click reset (rotate icon) in picker → tag returns to default neutral color
- [ ] Verify single-click on tag icon/title still navigates to tag page
- [ ] Verify double-click on tag title still opens rename input
- [ ] Test dark mode rendering of all 8 colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)