### PR TITLE
Add mobile responsive UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/thingstodo.svg" sizes="any" type="image/svg+xml" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#ef4444" />
     <meta name="description" content="Self-hosted Things 3-inspired task manager" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { Outlet, Navigate, useLocation } from 'react-router'
+import { Menu } from 'lucide-react'
 import { Sidebar } from './Sidebar'
 import { ShortcutsHelp } from './ShortcutsHelp'
 import { AppDndContext } from './AppDndContext'
@@ -17,6 +18,8 @@ export function AppLayout() {
   const { isLoading, error } = useMe()
   const location = useLocation()
   const expandTask = useAppStore((s) => s.expandTask)
+  const openMobileSidebar = useAppStore((s) => s.openMobileSidebar)
+  const closeMobileSidebar = useAppStore((s) => s.closeMobileSidebar)
   useGlobalShortcuts()
   useTaskShortcuts()
   useTheme()
@@ -27,6 +30,11 @@ export function AppLayout() {
   useEffect(() => {
     expandTask(null)
   }, [location.pathname, expandTask])
+
+  // Auto-close mobile sidebar on navigation
+  useEffect(() => {
+    closeMobileSidebar()
+  }, [location.pathname, closeMobileSidebar])
 
   if (isLoading) {
     return (
@@ -44,7 +52,15 @@ export function AppLayout() {
     <AppDndContext>
       <div className="flex h-screen bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
         <Sidebar />
-        <main className="flex-1 overflow-y-auto">
+        <main className="relative flex-1 overflow-y-auto">
+          <button
+            onClick={openMobileSidebar}
+            className="fixed left-4 z-30 rounded-lg bg-white/80 p-2 shadow-md backdrop-blur-sm md:hidden dark:bg-neutral-800/80"
+            style={{ top: 'calc(1rem + env(safe-area-inset-top, 0px))' }}
+            aria-label="Open sidebar"
+          >
+            <Menu size={20} />
+          </button>
           <Outlet />
         </main>
         <ShortcutsHelp />

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -47,7 +47,7 @@ export function CommandPalette() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[8vh] md:pt-[15vh]"
       onClick={(e) => {
         if (e.target === e.currentTarget) close()
       }}
@@ -59,7 +59,7 @@ export function CommandPalette() {
         }
       }}
     >
-      <Command className="w-full max-w-lg rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <Command className="mx-4 w-full max-w-lg rounded-xl bg-white shadow-2xl md:mx-0 dark:bg-neutral-800">
         <Command.Input
           autoFocus
           placeholder="Go to..."
@@ -132,7 +132,7 @@ export function CommandPalette() {
             </Command.Group>
           )}
         </Command.List>
-        <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 dark:border-neutral-700 dark:text-neutral-500">
+        <div className="hidden items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 md:flex dark:border-neutral-700 dark:text-neutral-500">
           <span>↑↓ Navigate · Enter Select</span>
           <span>Esc Close</span>
         </div>

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -31,7 +31,7 @@ export function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[8vh] md:pt-[15vh]"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel()
       }}
@@ -43,7 +43,7 @@ export function ConfirmDialog({
         }
       }}
     >
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <div className="mx-4 w-full max-w-lg rounded-xl bg-white shadow-2xl md:mx-0 dark:bg-neutral-800">
         <div className="p-4">
           <h3 className="text-base font-medium text-neutral-900 dark:text-neutral-100">
             {title}
@@ -53,7 +53,7 @@ export function ConfirmDialog({
           </p>
         </div>
         <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-2 dark:border-neutral-700">
-          <span className="text-xs text-neutral-400 dark:text-neutral-500">
+          <span className="hidden text-xs text-neutral-400 md:block dark:text-neutral-500">
             Enter to confirm · Esc to cancel
           </span>
           <div className="flex gap-2">

--- a/frontend/src/components/QuickEntry.tsx
+++ b/frontend/src/components/QuickEntry.tsx
@@ -106,7 +106,7 @@ export function QuickEntry() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[8vh] md:pt-[15vh]"
       onClick={(e) => {
         if (e.target === e.currentTarget) close()
       }}
@@ -135,7 +135,7 @@ export function QuickEntry() {
         }
       }}
     >
-      <div className="quick-entry-modal w-full max-w-lg rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <div className="quick-entry-modal mx-4 w-full max-w-lg rounded-xl bg-white shadow-2xl md:mx-0 dark:bg-neutral-800">
         <CreateMode
           title={title}
           onTitleChange={setTitle}
@@ -166,7 +166,7 @@ export function QuickEntry() {
           showDeadline={showDeadline}
           onToggleDeadline={setShowDeadline}
         />
-        <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 dark:border-neutral-700 dark:text-neutral-500">
+        <div className="hidden items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 md:flex dark:border-neutral-700 dark:text-neutral-500">
           <span>Enter to create · #tag $project *notes @when ^deadline !high</span>
           <span>Esc to close</span>
         </div>

--- a/frontend/src/components/SearchOverlay.tsx
+++ b/frontend/src/components/SearchOverlay.tsx
@@ -98,13 +98,13 @@ function SearchOverlayInner() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[8vh] md:pt-[15vh]"
       onClick={(e) => {
         if (e.target === e.currentTarget) close()
       }}
       onKeyDown={onKeyDown}
     >
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <div className="mx-4 w-full max-w-lg rounded-xl bg-white shadow-2xl md:mx-0 dark:bg-neutral-800">
         <div className="flex items-center gap-3 border-b border-neutral-200 px-4 py-3 dark:border-neutral-700">
           <Search size={16} className="shrink-0 text-neutral-400" />
           <input
@@ -163,7 +163,7 @@ function SearchOverlayInner() {
           )}
         </div>
 
-        <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 dark:border-neutral-700 dark:text-neutral-500">
+        <div className="hidden items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 md:flex dark:border-neutral-700 dark:text-neutral-500">
           <span>↑↓ Navigate · Enter Select</span>
           <span>Esc Close</span>
         </div>

--- a/frontend/src/components/ShortcutsHelp.tsx
+++ b/frontend/src/components/ShortcutsHelp.tsx
@@ -51,7 +51,7 @@ export function ShortcutsHelp() {
     <Dialog.Root open={open} onOpenChange={toggleShortcutsHelp}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/40" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 shadow-xl dark:bg-neutral-800">
+        <Dialog.Content className="fixed left-1/2 top-1/2 mx-4 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-4 shadow-xl md:mx-0 md:p-6 dark:bg-neutral-800">
           <div className="mb-4 flex items-center justify-between">
             <Dialog.Title className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
               Keyboard Shortcuts
@@ -61,7 +61,7 @@ export function ShortcutsHelp() {
             </Dialog.Close>
           </div>
 
-          <div className="grid grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
             <div className="space-y-4">
               <div>
                 <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ import {
   RotateCcw,
   ArrowDownAZ,
   ArrowDownZA,
-
+  X,
 } from 'lucide-react'
 import * as Collapsible from '@radix-ui/react-collapsible'
 import * as Popover from '@radix-ui/react-popover'
@@ -1001,7 +1001,7 @@ function NameInputDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[8vh] md:pt-[15vh]"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
@@ -1013,7 +1013,7 @@ function NameInputDialog({
         }
       }}
     >
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl dark:bg-neutral-800">
+      <div className="mx-4 w-full max-w-lg rounded-xl bg-white shadow-2xl md:mx-0 dark:bg-neutral-800">
         <div className="p-4">
           <div className="flex items-center gap-3">
             <span className="shrink-0 text-neutral-400">{icon}</span>
@@ -1039,7 +1039,7 @@ function NameInputDialog({
             <p className="mt-2 text-sm text-red-500">{errorMsg}</p>
           )}
         </div>
-        <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 dark:border-neutral-700 dark:text-neutral-500">
+        <div className="hidden items-center justify-between border-t border-neutral-200 px-4 py-2 text-xs text-neutral-400 md:flex dark:border-neutral-700 dark:text-neutral-500">
           <span>Enter to create {label}</span>
           <span>Esc to close</span>
         </div>
@@ -1135,74 +1135,15 @@ function LogoutButton({ size = 16 }: { size?: number }) {
 export function Sidebar() {
   const collapsed = useAppStore((s) => s.sidebarCollapsed)
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
+  const mobileSidebarOpen = useAppStore((s) => s.mobileSidebarOpen)
+  const closeMobileSidebar = useAppStore((s) => s.closeMobileSidebar)
   const navigate = useNavigate()
   const { data: counts } = useViewCounts()
   const overdueCount = counts?.overdue ?? 0
   const reviewCount = counts?.review ?? 0
 
-  if (collapsed) {
-    return (
-      <aside className="flex w-12 flex-col items-center border-r border-neutral-200 bg-neutral-50 py-3 dark:border-neutral-700 dark:bg-neutral-800">
-        <button
-          onClick={toggleSidebar}
-          className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
-          aria-label="Expand sidebar"
-        >
-          <img src="/thingstodo.svg" alt="ThingsToDo" className="h-[18px] w-[18px]" />
-        </button>
-        <LayoutGroup id="sidebar-collapsed">
-        <nav className="mt-4 flex flex-col items-center gap-1">
-          {smartLists.map(({ to, label, icon: Icon }) => (
-            <SidebarNavLink
-              key={to}
-              to={to}
-              className="group rounded-lg p-1.5 transition-colors"
-              activeClassName="text-red-700 dark:text-red-400"
-              inactiveClassName="text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
-              layoutId="sidebar-active-indicator-collapsed"
-            >
-              <Icon size={18} className="relative z-10" />
-              {label === 'Today' && overdueCount > 0 && (
-                <span className="absolute -right-0.5 -top-0.5 z-20 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-0.5 text-[8px] font-bold text-white">
-                  {overdueCount}
-                </span>
-              )}
-              {label === 'Inbox' && reviewCount > 0 && (
-                <span className="absolute -right-0.5 -top-0.5 z-20 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-0.5 text-[8px] font-bold text-white">
-                  {reviewCount}
-                </span>
-              )}
-              <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded-md bg-neutral-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 dark:bg-neutral-700">
-                {label}
-              </span>
-            </SidebarNavLink>
-          ))}
-        </nav>
-        </LayoutGroup>
-        <div className="mt-auto flex flex-col items-center gap-1">
-          <PlusMenu side="right" />
-        </div>
-      </aside>
-    )
-  }
-
-  return (
-    <aside className="flex w-72 flex-col border-r border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800">
-      <div className="flex items-center justify-between border-b border-neutral-200 px-3 py-3 dark:border-neutral-700">
-        <div className="flex items-center gap-3 px-3">
-          <div className="flex w-[18px] items-center justify-center">
-            <img src="/thingstodo.svg" alt="" className="h-6 w-6" />
-          </div>
-          <h1 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">ThingsToDo</h1>
-        </div>
-        <button
-          onClick={toggleSidebar}
-          className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
-          aria-label="Collapse sidebar"
-        >
-          <PanelLeftClose size={16} />
-        </button>
-      </div>
+  const expandedContent = (
+    <>
       <div className="flex-1 space-y-4 overflow-y-auto p-3">
         <LayoutGroup id="sidebar-expanded">
           <SmartListNav />
@@ -1224,6 +1165,107 @@ export function Sidebar() {
           </button>
         </div>
       </div>
-    </aside>
+    </>
+  )
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      {collapsed ? (
+        <aside className="hidden w-12 flex-col items-center border-r border-neutral-200 bg-neutral-50 py-3 md:flex dark:border-neutral-700 dark:bg-neutral-800">
+          <button
+            onClick={toggleSidebar}
+            className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+            aria-label="Expand sidebar"
+          >
+            <img src="/thingstodo.svg" alt="ThingsToDo" className="h-[18px] w-[18px]" />
+          </button>
+          <LayoutGroup id="sidebar-collapsed">
+          <nav className="mt-4 flex flex-col items-center gap-1">
+            {smartLists.map(({ to, label, icon: Icon }) => (
+              <SidebarNavLink
+                key={to}
+                to={to}
+                className="group rounded-lg p-1.5 transition-colors"
+                activeClassName="text-red-700 dark:text-red-400"
+                inactiveClassName="text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+                layoutId="sidebar-active-indicator-collapsed"
+              >
+                <Icon size={18} className="relative z-10" />
+                {label === 'Today' && overdueCount > 0 && (
+                  <span className="absolute -right-0.5 -top-0.5 z-20 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-0.5 text-[8px] font-bold text-white">
+                    {overdueCount}
+                  </span>
+                )}
+                {label === 'Inbox' && reviewCount > 0 && (
+                  <span className="absolute -right-0.5 -top-0.5 z-20 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-0.5 text-[8px] font-bold text-white">
+                    {reviewCount}
+                  </span>
+                )}
+                <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2 whitespace-nowrap rounded-md bg-neutral-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 dark:bg-neutral-700">
+                  {label}
+                </span>
+              </SidebarNavLink>
+            ))}
+          </nav>
+          </LayoutGroup>
+          <div className="mt-auto flex flex-col items-center gap-1">
+            <PlusMenu side="right" />
+          </div>
+        </aside>
+      ) : (
+        <aside className="hidden w-72 flex-col border-r border-neutral-200 bg-neutral-50 md:flex dark:border-neutral-700 dark:bg-neutral-800">
+          <div className="flex items-center justify-between border-b border-neutral-200 px-3 py-3 dark:border-neutral-700">
+            <div className="flex items-center gap-3 px-3">
+              <div className="flex w-[18px] items-center justify-center">
+                <img src="/thingstodo.svg" alt="" className="h-6 w-6" />
+              </div>
+              <h1 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">ThingsToDo</h1>
+            </div>
+            <button
+              onClick={toggleSidebar}
+              className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+              aria-label="Collapse sidebar"
+            >
+              <PanelLeftClose size={16} />
+            </button>
+          </div>
+          {expandedContent}
+        </aside>
+      )}
+
+      {/* Mobile drawer */}
+      {mobileSidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 md:hidden"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeMobileSidebar()
+          }}
+        >
+          <div className="absolute inset-0 bg-black/50" onClick={closeMobileSidebar} />
+          <aside
+            className="relative flex h-full w-72 flex-col bg-neutral-50 dark:bg-neutral-800"
+            style={{ paddingTop: 'env(safe-area-inset-top, 0px)', paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+          >
+            <div className="flex items-center justify-between border-b border-neutral-200 px-3 py-3 dark:border-neutral-700">
+              <div className="flex items-center gap-3 px-3">
+                <div className="flex w-[18px] items-center justify-center">
+                  <img src="/thingstodo.svg" alt="" className="h-6 w-6" />
+                </div>
+                <h1 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">ThingsToDo</h1>
+              </div>
+              <button
+                onClick={closeMobileSidebar}
+                className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+                aria-label="Close sidebar"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            {expandedContent}
+          </aside>
+        </div>
+      )}
+    </>
   )
 }

--- a/frontend/src/components/SortableTaskItem.tsx
+++ b/frontend/src/components/SortableTaskItem.tsx
@@ -269,7 +269,7 @@ export function SortableTaskItem({
       >
         {/* Drag handle */}
         <button
-          className="absolute -left-5 top-1/2 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 text-neutral-300 opacity-0 transition-opacity hover:text-neutral-500 group-hover/item:opacity-100 active:cursor-grabbing dark:text-neutral-600 dark:hover:text-neutral-400"
+          className="absolute -left-5 top-1/2 hidden -translate-y-1/2 cursor-grab touch-none rounded p-0.5 text-neutral-300 opacity-0 transition-opacity hover:text-neutral-500 group-hover/item:opacity-100 active:cursor-grabbing md:block dark:text-neutral-600 dark:hover:text-neutral-400"
           {...attributes}
           {...listeners}
           onClick={(e) => e.stopPropagation()}
@@ -277,7 +277,7 @@ export function SortableTaskItem({
           <GripVertical size={16} />
         </button>
 
-        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+        <div className="shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0" onClick={(e) => e.stopPropagation()}>
           {task.status === 'canceled' || task.status === 'wont_do' ? (
             <TaskStatusIcon status={task.status} />
           ) : (
@@ -295,7 +295,7 @@ export function SortableTaskItem({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             {editing ? (
               <>
                 <input
@@ -379,7 +379,7 @@ export function SortableTaskItem({
               </span>
             )}
             {!editing && (
-              <div className="ml-auto flex items-center gap-2 text-xs text-neutral-400">
+              <div className="flex items-center gap-2 text-xs text-neutral-400 md:ml-auto">
                 {task.deadline && (
                   <span className="flex items-center gap-1 text-red-500">
                     <Flag size={12} />

--- a/frontend/src/components/TaskDetail.tsx
+++ b/frontend/src/components/TaskDetail.tsx
@@ -209,7 +209,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
 
   return (
     <div
-      className="space-y-3 border-t border-neutral-100 py-4 pl-[64px] pr-6 dark:border-neutral-700"
+      className="space-y-3 border-t border-neutral-100 py-4 pl-6 pr-4 md:pl-[64px] md:pr-6 dark:border-neutral-700"
       onKeyDown={handleKeyDown}
     >
       {/* Notes — shown when has notes or toggled */}
@@ -349,7 +349,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         {!hasNotes && !showNotes && (
           <button
             onClick={() => { setShowNotes(true); setEditingNotes(true) }}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Add notes"
             title="Notes"
           >
@@ -359,7 +359,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         {!hasWhen && !showWhen && (
           <button
             onClick={() => setShowWhen(true)}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Set when date"
             title="When"
           >
@@ -369,7 +369,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         {!hasDeadline && !showDeadline && (
           <button
             onClick={() => setShowDeadline(true)}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Set deadline"
             title="Deadline"
           >
@@ -379,7 +379,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         {!hasChecklist && !showChecklist && (
           <button
             onClick={() => setShowChecklist(true)}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Add checklist"
             title="Checklist"
           >
@@ -401,7 +401,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         ) : (
           <button
             onClick={() => updateTask.mutate({ id: taskId, data: { high_priority: true } })}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Set high priority"
             title="High priority"
           >
@@ -411,7 +411,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         {hasSiYuan ? (
           <button
             disabled
-            className="rounded-md p-1 text-neutral-300 cursor-not-allowed dark:text-neutral-600"
+            className="rounded-md p-2 md:p-1 text-neutral-300 cursor-not-allowed dark:text-neutral-600"
             aria-label={hasRepeatRule ? 'Recurring disabled — remove SiYuan link to edit' : 'Recurring not available for SiYuan-linked tasks'}
             title={hasRepeatRule ? 'Has a repeat rule — remove SiYuan link to edit' : 'Recurring not available for SiYuan-linked tasks'}
           >
@@ -430,7 +430,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
         ) : !showRepeat && (
           <button
             onClick={() => setShowRepeat(true)}
-            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-label="Repeat"
             title="Repeat"
           >
@@ -442,7 +442,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
             <>
               <button
                 onClick={handleCancel}
-                className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+                className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
                 aria-label="Cancel task"
                 title="Cancel"
               >
@@ -450,7 +450,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
               </button>
               <button
                 onClick={handleWontDo}
-                className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+                className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
                 aria-label="Won't do task"
                 title="Won't do"
               >
@@ -460,7 +460,7 @@ export function TaskDetail({ taskId }: TaskDetailProps) {
           )}
           <button
             onClick={handleDelete}
-            className="rounded-md p-1 text-neutral-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
             aria-label="Delete task"
             title="Delete"
           >
@@ -554,7 +554,7 @@ function FileUploadButton({ taskId }: { taskId: string }) {
       />
       <button
         onClick={() => fileInputRef.current?.click()}
-        className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+        className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
         aria-label="Attach file"
         title="Attach file"
       >
@@ -648,7 +648,7 @@ function LinkAddButton({ taskId }: { taskId: string }) {
   return (
     <button
       onClick={() => setAdding(true)}
-      className="rounded-md p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+      className="rounded-md p-2 md:p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
       aria-label="Add link"
       title="Add link"
     >

--- a/frontend/src/components/TaskItem.tsx
+++ b/frontend/src/components/TaskItem.tsx
@@ -253,14 +253,14 @@ export function TaskItem({ task, showProject = true, hideWhenDate = false, showR
       >
         {/* Drag handle */}
         <button
-          className="absolute -left-5 top-1/2 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 text-neutral-300 opacity-0 transition-opacity hover:text-neutral-500 group-hover/item:opacity-100 active:cursor-grabbing dark:text-neutral-600 dark:hover:text-neutral-400"
+          className="absolute -left-5 top-1/2 hidden -translate-y-1/2 cursor-grab touch-none rounded p-0.5 text-neutral-300 opacity-0 transition-opacity hover:text-neutral-500 group-hover/item:opacity-100 active:cursor-grabbing md:block dark:text-neutral-600 dark:hover:text-neutral-400"
           {...attributes}
           {...listeners}
           onClick={(e) => e.stopPropagation()}
         >
           <GripVertical size={16} />
         </button>
-        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+        <div className="shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0" onClick={(e) => e.stopPropagation()}>
           {task.status === 'canceled' || task.status === 'wont_do' ? (
             <TaskStatusIcon status={task.status} />
           ) : (
@@ -278,7 +278,7 @@ export function TaskItem({ task, showProject = true, hideWhenDate = false, showR
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             {editing ? (
               <>
                 <input
@@ -360,7 +360,7 @@ export function TaskItem({ task, showProject = true, hideWhenDate = false, showR
               </span>
             )}
             {!editing && (
-              <div className="ml-auto flex items-center gap-2 text-xs text-neutral-400">
+              <div className="flex items-center gap-2 text-xs text-neutral-400 md:ml-auto">
                 {task.deadline && (
                   <span className="flex items-center gap-1 text-red-500">
                     <Flag size={12} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,3 +4,12 @@
 
 html { color-scheme: light; }
 html.dark { color-scheme: dark; }
+
+@supports (padding-top: env(safe-area-inset-top)) {
+  #root {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}

--- a/frontend/src/pages/AnytimeView.tsx
+++ b/frontend/src/pages/AnytimeView.tsx
@@ -7,14 +7,14 @@ export function AnytimeView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Anytime</h2>
 
       {data?.no_area && data.no_area.standalone_tasks.length > 0 && (

--- a/frontend/src/pages/AreaView.tsx
+++ b/frontend/src/pages/AreaView.tsx
@@ -20,7 +20,7 @@ export function AreaView() {
 
   if (isLoading || !area) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
@@ -29,7 +29,7 @@ export function AreaView() {
   const hasProjects = area.projects.length > 0
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <div className="flex items-center justify-between">
         <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{area.title}</h2>
         {!hasProjects && (

--- a/frontend/src/pages/InboxView.tsx
+++ b/frontend/src/pages/InboxView.tsx
@@ -9,7 +9,7 @@ export function InboxView() {
   const hasReview = (data?.review.length ?? 0) > 0
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Inbox</h2>
       {isLoading ? (
         <p className="py-8 text-center text-sm text-neutral-400">Loading...</p>

--- a/frontend/src/pages/LogbookView.tsx
+++ b/frontend/src/pages/LogbookView.tsx
@@ -27,14 +27,14 @@ export function LogbookView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Completed</h2>
         {hasTasks && (

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -16,7 +16,7 @@ export function ProjectView() {
 
   if (isLoading || !project) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
@@ -28,7 +28,7 @@ export function ProjectView() {
       : 0
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <div className="flex items-center justify-between">
         <h2 className="mb-1 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{project.title}</h2>
         <button

--- a/frontend/src/pages/SettingsView.tsx
+++ b/frontend/src/pages/SettingsView.tsx
@@ -88,7 +88,7 @@ export function SettingsView() {
   if (!settings) return null
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h1 className="mb-6 text-xl font-semibold text-neutral-900 dark:text-neutral-100">Settings</h1>
 
       <section className="mb-8">

--- a/frontend/src/pages/SomedayView.tsx
+++ b/frontend/src/pages/SomedayView.tsx
@@ -7,14 +7,14 @@ export function SomedayView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Someday</h2>
 
       {data?.no_area && data.no_area.standalone_tasks.length > 0 && (

--- a/frontend/src/pages/TagView.tsx
+++ b/frontend/src/pages/TagView.tsx
@@ -18,14 +18,14 @@ export function TagView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <div className="flex items-center justify-between">
         <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">
           {tag?.title ?? 'Tag'}

--- a/frontend/src/pages/TaskPermalinkView.tsx
+++ b/frontend/src/pages/TaskPermalinkView.tsx
@@ -16,7 +16,7 @@ export function TaskPermalinkView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
@@ -24,14 +24,14 @@ export function TaskPermalinkView() {
 
   if (error || !task) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-500">Task not found.</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-4 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{task.title}</h2>
       <TaskDetail taskId={task.id} />
     </div>

--- a/frontend/src/pages/TodayView.tsx
+++ b/frontend/src/pages/TodayView.tsx
@@ -24,14 +24,14 @@ export function TodayView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Today</h2>
 
       {/* Overdue tasks */}

--- a/frontend/src/pages/TrashView.tsx
+++ b/frontend/src/pages/TrashView.tsx
@@ -27,14 +27,14 @@ export function TrashView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Trash</h2>
         {hasTasks && (

--- a/frontend/src/pages/UpcomingView.tsx
+++ b/frontend/src/pages/UpcomingView.tsx
@@ -13,14 +13,14 @@ export function UpcomingView() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <div className="px-4 pt-14 pb-4 md:p-6">
         <p className="text-sm text-neutral-400">Loading...</p>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className="mx-auto max-w-3xl px-4 pt-14 pb-4 md:p-6">
       <h2 className="mb-3 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Upcoming</h2>
       {data?.overdue && data.overdue.length > 0 && (
         <div className="mb-6">

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -65,6 +65,11 @@ interface AppStore {
   // Signal that a detail field interaction completed — title editing should resume
   detailFieldCompleted: boolean
   setDetailFieldCompleted: (v: boolean) => void
+
+  // Mobile sidebar drawer
+  mobileSidebarOpen: boolean
+  openMobileSidebar: () => void
+  closeMobileSidebar: () => void
 }
 
 function getInitialCollapsedAreas(): Set<string> {
@@ -148,6 +153,10 @@ export const useAppStore = create<AppStore>((set) => ({
 
   detailFieldCompleted: false,
   setDetailFieldCompleted: (v) => set({ detailFieldCompleted: v }),
+
+  mobileSidebarOpen: false,
+  openMobileSidebar: () => set({ mobileSidebarOpen: true }),
+  closeMobileSidebar: () => set({ mobileSidebarOpen: false }),
 
   selectedTaskIds: new Set(),
   toggleTaskSelection: (id, multi) =>


### PR DESCRIPTION
## Summary
- Mobile sidebar drawer with hamburger button, auto-close on navigate
- Responsive page padding and safe area insets for notch/home indicator
- 44px touch targets on checkboxes, hidden drag handles, wrapping metadata
- All modals repositioned higher with side margins, keyboard hints hidden on mobile
- Desktop (>= 768px) completely unchanged

## Test plan
- [ ] Chrome DevTools → iPhone SE (375px) and iPhone 14 Pro (393px)
- [ ] Sidebar hidden, hamburger visible, drawer opens/closes
- [ ] Page content has comfortable padding, no text touching edges
- [ ] Task checkboxes easy to tap, metadata wraps when cramped
- [ ] Modals have side margins and don't overflow
- [ ] Resize to >= 768px → desktop unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)